### PR TITLE
Include dependencies in gemspec

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -1,9 +1,16 @@
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = "1.0"
+  s.version = "1.0.1"
+
+  s.add_dependency 'builder'
+  s.add_dependency 'oauth', '~0.4.5'
+  s.add_dependency 'uuid'
+
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'ruby-deug'
 
   s.authors = ["Instructure"]
-  s.date = %q{2012-03-10}
+  s.date = %q{2012-03-13}
   s.extra_rdoc_files = %W(LICENSE)
   s.files = %W(
           LICENSE
@@ -17,7 +24,7 @@ Gem::Specification.new do |s|
           lib/ims/lti/tool_consumer.rb
           lib/ims/lti/tool_provider.rb
           ims-lti.gemspec
-)
+  )
   s.homepage = %q{http://github.com/instructure/ims-lti}
   s.require_paths = %W(lib)
   s.summary = %q{Ruby library for creating IMS LTI tool providers and consumers}


### PR DESCRIPTION
Dependencies were missing in gemspec, causing loading problems. This commit adds the dependencies to the gemspec so that they're properly loaded during a `gem install.`
