### PR TITLE
fix launch param processing for custom/ext

### DIFF
--- a/lib/ims/lti/launch_params.rb
+++ b/lib/ims/lti/launch_params.rb
@@ -137,9 +137,9 @@ module IMS::LTI
       params.each_pair do |key, val|
         if LAUNCH_DATA_PARAMETERS.member?(key)
           self.send("#{key}=", val)
-        elsif key =~ /custom_(.*)/
+        elsif key =~ /\Acustom_(.+)\Z/
           @custom_params[$1] = val
-        elsif key =~ /ext_(.*)/
+        elsif key =~ /\Aext_(.+)\Z/
           @ext_params[$1] = val
         end
       end

--- a/spec/launch_params_spec.rb
+++ b/spec/launch_params_spec.rb
@@ -8,12 +8,12 @@ describe IMS::LTI::LaunchParams do
       end
 
       it "should process parameters" do
-        @params.each_pair do |key, val|
-          @tool.send(key).should == val unless key =~ /custom_|ext_|roles/
+        valid_params.each_pair do |key, val|
+          @tool.send(key).should == val unless key =~ /\A(?:custom_.+|ext_.+|roles)\Z/
         end
         @tool.roles.should == ["learner", "instructor", "observer", "urn:lti:role:ims/lis/member", "mentor/mentor", "administrator", "urn:lti:role:ims/lis/teachingassistant/teachingassistantsection"]
 
-        @tool.to_params.should == @params
+        @tool.to_params.should == valid_params
       end
 
       it "should handle custom/extension parameters" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,9 +15,15 @@ def create_params
             "launch_presentation_return_url" => "http://example.com/lti_return",
             "custom_param1" => "custom1",
             "custom_param2" => "custom2",
+            "invalid_ext_param" => "invalid_param",
+            "invalid_custom_param" => "invalid_custom",
             "ext_lti_message_type" => "extension-lti-launch",
             "roles" => "learner,instructor,observer,urn:lti:role:ims/lis/member,mentor/mentor,administrator,urn:lti:role:ims/lis/teachingassistant/teachingassistantsection"
     }
+end
+
+def valid_params
+  @params.reject {|p| p =~ /\Ainvalid_.+\Z/ }
 end
 
 def create_test_tp


### PR DESCRIPTION
shouldn't process params that don't begin with 'custom_' or 'ext_'

the regex being used wasn't restrictive enough :)
