### PR TITLE
Added a debug message for wrong XML response in 'process_xml'

### DIFF
--- a/lib/ims/lti.rb
+++ b/lib/ims/lti.rb
@@ -25,11 +25,14 @@ module IMS # :nodoc:
   #
   #    require 'ims/lti'
   module LTI
-    
+
     # The versions of LTI this library supports
     VERSIONS = %w{1.0 1.1}
-    
+
     class InvalidLTIConfigError < StandardError
+    end
+
+    class XMLParseError < StandardError
     end
 
     # POST a signed oauth request with the given key/secret/data

--- a/lib/ims/lti/outcome_response.rb
+++ b/lib/ims/lti/outcome_response.rb
@@ -107,20 +107,20 @@ module IMS::LTI
     def process_xml(xml)
       begin
         doc = REXML::Document.new xml
-        @message_identifier = doc.text("//imsx_statusInfo/imsx_messageIdentifier").to_s
-        @code_major = doc.text("//imsx_statusInfo/imsx_codeMajor")
-        @code_major.downcase! if @code_major
-        @severity = doc.text("//imsx_statusInfo/imsx_severity")
-        @severity.downcase! if @severity
-        @description = doc.text("//imsx_statusInfo/imsx_description")
-        @description = @description.to_s if @description
-        @message_ref_identifier = doc.text("//imsx_statusInfo/imsx_messageRefIdentifier")
-        @operation = doc.text("//imsx_statusInfo/imsx_operationRefIdentifier")
-        @score = doc.text("//readResultResponse//resultScore/textString")
-        @score = @score.to_s if @score
       rescue => e
-        raise StandardError, "Wrong XML response, original error:\n#{e}.\nOriginal xml: '#{xml}'"
+        raise IMS::LTI::XMLParseError, "#{e}\nOriginal xml: '#{xml}'"
       end
+      @message_identifier = doc.text("//imsx_statusInfo/imsx_messageIdentifier").to_s
+      @code_major = doc.text("//imsx_statusInfo/imsx_codeMajor")
+      @code_major.downcase! if @code_major
+      @severity = doc.text("//imsx_statusInfo/imsx_severity")
+      @severity.downcase! if @severity
+      @description = doc.text("//imsx_statusInfo/imsx_description")
+      @description = @description.to_s if @description
+      @message_ref_identifier = doc.text("//imsx_statusInfo/imsx_messageRefIdentifier")
+      @operation = doc.text("//imsx_statusInfo/imsx_operationRefIdentifier")
+      @score = doc.text("//readResultResponse//resultScore/textString")
+      @score = @score.to_s if @score
     end
 
     # Generate XML based on the current configuration

--- a/lib/ims/lti/outcome_response.rb
+++ b/lib/ims/lti/outcome_response.rb
@@ -119,7 +119,7 @@ module IMS::LTI
         @score = doc.text("//readResultResponse//resultScore/textString")
         @score = @score.to_s if @score
       rescue => e
-        raise IMS::LTI::InvalidLTIConfigError, "Wrong XML response. Original xml: '#{xml}'"
+        raise StandardError, "Wrong XML response, original error:\n#{e}.\nOriginal xml: '#{xml}'"
       end
     end
 

--- a/lib/ims/lti/outcome_response.rb
+++ b/lib/ims/lti/outcome_response.rb
@@ -46,7 +46,7 @@ module IMS::LTI
   #
   class OutcomeResponse
     include IMS::LTI::Extensions::Base
-    
+
     attr_accessor :request_type, :score, :message_identifier, :response_code,
             :post_response, :code_major, :severity, :description, :operation,
             :message_ref_identifier
@@ -70,7 +70,7 @@ module IMS::LTI
       response = OutcomeResponse.new
       response.process_post_response(post_response)
     end
-    
+
     def process_post_response(post_response)
       self.post_response = post_response
       self.response_code = post_response.code
@@ -105,18 +105,22 @@ module IMS::LTI
 
     # Parse Outcome Response data from XML
     def process_xml(xml)
-      doc = REXML::Document.new xml
-      @message_identifier = doc.text("//imsx_statusInfo/imsx_messageIdentifier").to_s
-      @code_major = doc.text("//imsx_statusInfo/imsx_codeMajor")
-      @code_major.downcase! if @code_major
-      @severity = doc.text("//imsx_statusInfo/imsx_severity")
-      @severity.downcase! if @severity
-      @description = doc.text("//imsx_statusInfo/imsx_description")
-      @description = @description.to_s if @description
-      @message_ref_identifier = doc.text("//imsx_statusInfo/imsx_messageRefIdentifier")
-      @operation = doc.text("//imsx_statusInfo/imsx_operationRefIdentifier")
-      @score = doc.text("//readResultResponse//resultScore/textString")
-      @score = @score.to_s if @score
+      begin
+        doc = REXML::Document.new xml
+        @message_identifier = doc.text("//imsx_statusInfo/imsx_messageIdentifier").to_s
+        @code_major = doc.text("//imsx_statusInfo/imsx_codeMajor")
+        @code_major.downcase! if @code_major
+        @severity = doc.text("//imsx_statusInfo/imsx_severity")
+        @severity.downcase! if @severity
+        @description = doc.text("//imsx_statusInfo/imsx_description")
+        @description = @description.to_s if @description
+        @message_ref_identifier = doc.text("//imsx_statusInfo/imsx_messageRefIdentifier")
+        @operation = doc.text("//imsx_statusInfo/imsx_operationRefIdentifier")
+        @score = doc.text("//readResultResponse//resultScore/textString")
+        @score = @score.to_s if @score
+      rescue => e
+        raise IMS::LTI::InvalidLTIConfigError, "Wrong XML response. Original xml: '#{xml}'"
+      end
     end
 
     # Generate XML based on the current configuration

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -94,7 +94,7 @@ describe IMS::LTI::OutcomeResponse do
 
   it "should raise an error with wrong xml" do
     res = IMS::LTI::OutcomeResponse.new
-    expect { res.process_xml(wrong_xml) }.to raise_error(IMS::LTI::InvalidLTIConfigError)
+    expect { res.process_xml(wrong_xml) }.to raise_error(StandardError)
   end
 
 end

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -23,7 +23,7 @@ describe IMS::LTI::OutcomeResponse do
 </imsx_POXEnvelopeResponse>
   XML
 
-  bad_xml = "This is a bad XML file without any tags but with some special chars %ùp<>/:!"
+  bad_xml = "This is a bad XML file with bad tags <root_tag></root_tag><second_root_tag></second_root_tag>"
 
   def mock_response(xml)
     @fake = Object

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -94,7 +94,6 @@ describe IMS::LTI::OutcomeResponse do
 
   it "should raise an error with bad xml" do
     res = IMS::LTI::OutcomeResponse.new
-    puts res.process_xml(bad_xml)
     expect { res.process_xml(bad_xml) }.to raise_error(IMS::LTI::XMLParseError)
   end
 

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -23,6 +23,8 @@ describe IMS::LTI::OutcomeResponse do
 </imsx_POXEnvelopeResponse>
   XML
 
+  wrong_xml = "This is a wrong XML file without any tags but with some chars %ùp<>/:!"
+
   def mock_response(xml)
     @fake = Object
     OAuth::AccessToken.stub(:new).and_return(@fake)
@@ -88,6 +90,11 @@ describe IMS::LTI::OutcomeResponse do
     res.process_xml(response_xml)
     alt = response_xml.gsub("\n",'')
     res.generate_response_xml.should == alt
+  end
+
+  it "should raise an error with wrong xml" do
+    res = IMS::LTI::OutcomeResponse.new
+    expect { res.process_xml(wrong_xml) }.to raise_error(IMS::LTI::InvalidLTIConfigError)
   end
 
 end

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -23,7 +23,7 @@ describe IMS::LTI::OutcomeResponse do
 </imsx_POXEnvelopeResponse>
   XML
 
-  wrong_xml = "This is a wrong XML file without any tags but with some chars %ùp<>/:!"
+  bad_xml = "This is a bad XML file without any tags but with some special chars %ùp<>/:!"
 
   def mock_response(xml)
     @fake = Object
@@ -92,9 +92,10 @@ describe IMS::LTI::OutcomeResponse do
     res.generate_response_xml.should == alt
   end
 
-  it "should raise an error with wrong xml" do
+  it "should raise an error with bad xml" do
     res = IMS::LTI::OutcomeResponse.new
-    expect { res.process_xml(wrong_xml) }.to raise_error(StandardError)
+    puts res.process_xml(bad_xml)
+    expect { res.process_xml(bad_xml) }.to raise_error(IMS::LTI::XMLParseError)
   end
 
 end

--- a/spec/tool_config_spec.rb
+++ b/spec/tool_config_spec.rb
@@ -37,12 +37,12 @@ describe IMS::LTI::ToolConfig do
   <cartridge_bundle identifierref="BLTI001_Bundle"/>
 </cartridge_basiclti_link>
 XML
-  
+
   # the generated order of the schema stuff is random, just ignore it
   def clear_shema_stuffs(text)
     text.gsub(/<cartridge_basiclti_link[^>]*>/, "<cartridge_basiclti_link>")
   end
-  
+
   it "should generate the expected config xml" do
     config = IMS::LTI::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
     config.description = "Description of boringness"
@@ -56,15 +56,15 @@ XML
     config.vendor_contact_name = "Joe Support"
 
     config.set_custom_param("custom2", "customval2")
-    
+
     config.set_ext_params("example.com", {"extkey1" => "extval1"})
     config.set_ext_param("example.com", "extkey2", "extval2")
     config.set_ext_param("example.com", "extopt1", {"optkey1" => "optval1", "optkey2" => "optval2"})
-    
+
     config.set_ext_param("two.example.com", "ext1key", "ext1val")
 
     config.cartridge_bundle = "BLTI001_Bundle"
-    
+
     clear_shema_stuffs(config.to_xml(:indent => 2)).should == clear_shema_stuffs(cc_lti_xml)
   end
 
@@ -72,10 +72,10 @@ XML
     config = IMS::LTI::ToolConfig.create_from_xml(cc_lti_xml)
     clear_shema_stuffs(config.to_xml(:indent => 2)).should == clear_shema_stuffs(cc_lti_xml)
   end
-  
+
   it "should not allow creating invalid config xml" do
     config = IMS::LTI::ToolConfig.new("title" => "Test Config")
     expect { config.to_xml }.to raise_error(IMS::LTI::InvalidLTIConfigError)
   end
-  
+
 end


### PR DESCRIPTION
Hi there :)

I'm making a small pull request to add some debug information when the gem is trying to process a bad xml response. 
Along with the error message I also add the original XML content so that we can know for sure what was the response and what is going on. 

I also added a spec to test this error message in outcome_response_spec.rb. 

I think it may benefit people to debug their apps. 

Let me know if I should modify my PR. 
Regis. 
