### PR TITLE
Allow for unlimited nesting of options and properties

### DIFF
--- a/lib/ims/lti/tool_config.rb
+++ b/lib/ims/lti/tool_config.rb
@@ -115,13 +115,7 @@ module IMS::LTI
           platform = vendor_ext_node.attributes['platform']
           properties = {}
           set_properties(properties, vendor_ext_node)
-          REXML::XPath.each(vendor_ext_node, 'lticm:options', LTI_NAMESPACES) do |options_node|
-            opt_name = options_node.attributes['name']
-            options = {}
-            set_properties(options, options_node)
-            properties[opt_name] = options
-          end
-
+          set_options(properties, vendor_ext_node)
           self.set_ext_params(platform, properties)
         end
 
@@ -220,6 +214,16 @@ module IMS::LTI
     def set_properties(hash, node)
       REXML::XPath.each(node, 'lticm:property', LTI_NAMESPACES) do |prop|
         hash[prop.attributes['name']] = prop.text
+      end
+    end
+
+    def set_options(hash, node)
+      REXML::XPath.each(node, 'lticm:options', LTI_NAMESPACES) do |options_node|
+        opt_name = options_node.attributes['name']
+        options = {}
+        set_properties(options, options_node)
+        set_options(options, options_node)
+        hash[opt_name] = options
       end
     end
 

--- a/lib/ims/lti/tool_config.rb
+++ b/lib/ims/lti/tool_config.rb
@@ -175,17 +175,7 @@ module IMS::LTI
             ext_params = @extensions[ext_platform]
             blti_node.blti(:extensions, :platform => ext_platform) do |ext_node|
               ext_params.keys.sort.each do |key|
-                val = ext_params[key]
-                if val.is_a?(Hash)
-                  ext_node.lticm(:options, :name => key) do |type_node|
-                    val.keys.sort.each do |p_key|
-                      p_val = val[p_key]
-                      type_node.lticm :property, p_val, 'name' => p_key
-                    end
-                  end
-                else
-                  ext_node.lticm :property, val, 'name' => key
-                end
+                nest_xml(ext_node, key, ext_params[key])
               end
             end
           end
@@ -198,6 +188,18 @@ module IMS::LTI
     end
 
     private
+
+    def nest_xml(ext_node, key, value)
+      if value.is_a?(Hash)
+        ext_node.lticm(:options, :name => key) do |type_node|
+          value.keys.sort.each do |sub_key|
+            nest_xml(type_node, sub_key, value[sub_key])
+          end
+        end
+      else
+        ext_node.lticm :property, value, 'name' => key
+      end
+    end
 
     def get_node_text(node, path)
       if val = REXML::XPath.first(node, path, LTI_NAMESPACES)

--- a/spec/tool_config_spec.rb
+++ b/spec/tool_config_spec.rb
@@ -29,6 +29,10 @@ describe IMS::LTI::ToolConfig do
     <lticm:options name="extopt1">
       <lticm:property name="optkey1">optval1</lticm:property>
       <lticm:property name="optkey2">optval2</lticm:property>
+      <lticm:options name="subopt1">
+        <lticm:property name="suboptkey1">suboptval1</lticm:property>
+        <lticm:property name="suboptkey2">suboptval2</lticm:property>
+      </lticm:options>
     </lticm:options>
   </blti:extensions>
   <blti:extensions platform="two.example.com">
@@ -37,12 +41,12 @@ describe IMS::LTI::ToolConfig do
   <cartridge_bundle identifierref="BLTI001_Bundle"/>
 </cartridge_basiclti_link>
 XML
-  
+
   # the generated order of the schema stuff is random, just ignore it
   def clear_shema_stuffs(text)
     text.gsub(/<cartridge_basiclti_link[^>]*>/, "<cartridge_basiclti_link>")
   end
-  
+
   it "should generate the expected config xml" do
     config = IMS::LTI::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
     config.description = "Description of boringness"
@@ -56,15 +60,22 @@ XML
     config.vendor_contact_name = "Joe Support"
 
     config.set_custom_param("custom2", "customval2")
-    
+
     config.set_ext_params("example.com", {"extkey1" => "extval1"})
     config.set_ext_param("example.com", "extkey2", "extval2")
-    config.set_ext_param("example.com", "extopt1", {"optkey1" => "optval1", "optkey2" => "optval2"})
-    
+    config.set_ext_param("example.com", "extopt1", {
+      "optkey1" => "optval1",
+      "optkey2" => "optval2",
+      "subopt1" => {
+        "suboptkey1" => "suboptval1",
+        "suboptkey2" => "suboptval2"
+      }
+    })
+
     config.set_ext_param("two.example.com", "ext1key", "ext1val")
 
     config.cartridge_bundle = "BLTI001_Bundle"
-    
+
     clear_shema_stuffs(config.to_xml(:indent => 2)).should == clear_shema_stuffs(cc_lti_xml)
   end
 
@@ -72,10 +83,10 @@ XML
     config = IMS::LTI::ToolConfig.create_from_xml(cc_lti_xml)
     clear_shema_stuffs(config.to_xml(:indent => 2)).should == clear_shema_stuffs(cc_lti_xml)
   end
-  
+
   it "should not allow creating invalid config xml" do
     config = IMS::LTI::ToolConfig.new("title" => "Test Config")
     expect { config.to_xml }.to raise_error(IMS::LTI::InvalidLTIConfigError)
   end
-  
+
 end


### PR DESCRIPTION
Right now it is impossible to create a configuration with nesting beyond a certain point. This PR enables unlimited nesting of options and properties in the XML config. For example: 

```ruby
tc.set_ext_params "canvas.instructure.com", {
  privacy_level: "public",
  course_navigation: {
    enabled: true,
    custom_fields: {
      previous_context_ids: "$Canvas.course.previousContextIds",
      previous_course_ids: "$Canvas.course.previousCourseIds"
    }
  }
}
```

Becomes:

```xml
<blti:extensions platform="canvas.instructure.com">
  <lticm:options name="course_navigation">
    <lticm:options name="custom_fields">
      <lticm:property name="previous_context_ids">$Canvas.course.previousContextIds</lticm:property>
      <lticm:property name="previous_course_ids">$Canvas.course.previousCourseIds</lticm:property>
    </lticm:options>
    <lticm:property name="enabled">true</lticm:property>
  </lticm:options>
  <lticm:property name="privacy_level">public</lticm:property>
</blti:extensions>
```