### PR TITLE
Improve the message for ToolProxyRegistrationError

### DIFF
--- a/lib/ims/lti/errors/tool_proxy_registration_error.rb
+++ b/lib/ims/lti/errors/tool_proxy_registration_error.rb
@@ -5,7 +5,11 @@ module IMS::LTI::Errors
     def initialize(response_status, response_body = nil)
       @response_status = response_status
       @response_body = response_body
+      super <<-EOF
+Unexpected response for tool proxy registration.
+HTTP Response Status: #{response_status}
+HTTP Response Body: #{response_body}
+EOF
     end
-
   end
 end

--- a/spec/ims/lti/errors/tool_proxy_registration_error_spec.rb
+++ b/spec/ims/lti/errors/tool_proxy_registration_error_spec.rb
@@ -9,5 +9,10 @@ module IMS::LTI::Errors
       expect(s.response_status).to eq 401
     end
 
+    it 'must construct a descriptive message from the constructor arguments' do
+      exception = described_class.new(401, 'test')
+      expect(exception.message).to include '401'
+      expect(exception.message).to include 'test'
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit the message was just the class name, this is an attempt to be more descriptive.