### PR TITLE
Add support for detecting Observers

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+2016-06-16 Version 1.1.12
+    * Add support for detecting observer role
+
 2015-02-20 Version 1.1.8
     * Replace usage of the 'uuid' gem with SecureRandom
     * Update the outcome extension doc example
@@ -24,13 +27,13 @@
     * Fix tests reliant on random ordering
     * Add rails 3 note to readme install docs
     * Create Changelog
-    
+
 
 2012-03-14 Version 1.0.2
 
     * Refactor OAuth validation into its own module
-    
-    
+
+
 2012-03-13 Version 1.0.1
 
     * Add gem dependencies to gemspec

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = "1.1.10"
+  s.version = "1.1.12"
 
   s.add_dependency 'builder'
   s.add_dependency 'oauth', '~> 0.4.5'

--- a/lib/ims/lti/role_checks.rb
+++ b/lib/ims/lti/role_checks.rb
@@ -92,5 +92,10 @@ module IMS::LTI
     def context_ta?
       has_exact_role?('TeachingAssistant') || has_exact_role?('urn:lti:role:ims/lis/TeachingAssistant')
     end
+
+    # Convenience method for checking if the user has 'Observer' role in the current launch context
+    def context_observer?
+      has_exact_role?('Observer') || has_exact_role?('urn:lti:instrole:ims/lis/Observer')
+    end
   end
 end

--- a/spec/tool_provider_spec.rb
+++ b/spec/tool_provider_spec.rb
@@ -69,14 +69,16 @@ describe IMS::LTI::ToolProvider do
   end
 
   it "should recognize other context roles" do
-    @tp.roles = "Mentor,TeachingAssistant,ContentDeveloper"
+    @tp.roles = "Mentor,TeachingAssistant,ContentDeveloper,Observer"
     @tp.context_content_developer?.should == true
     @tp.context_mentor? == true
     @tp.context_ta? == true
-    @tp.roles = "urn:lti:role:ims/lis/Mentor,urn:lti:role:ims/lis/TeachingAssistant,urn:lti:role:ims/lis/ContentDeveloper"
+    @tp.context_observer? == true
+    @tp.roles = "urn:lti:role:ims/lis/Mentor,urn:lti:role:ims/lis/TeachingAssistant,urn:lti:role:ims/lis/ContentDeveloper,urn:lti:instrole:ims/lis/Observer"
     @tp.context_content_developer?.should == true
     @tp.context_mentor? == true
     @tp.context_ta? == true
+    @tp.context_observer? == true
   end
 
   it "should recognize the deprecated roles" do


### PR DESCRIPTION
Gives the ability to detect if the current user is Observer. Currently able to determine all canvas roles except for observer. 