### PR TITLE
Exposes public OutcomeRequest#generate_request_xml method

### DIFF
--- a/lib/ims/lti/outcome_request.rb
+++ b/lib/ims/lti/outcome_request.rb
@@ -148,37 +148,8 @@ module IMS::LTI
       extention_process_xml(doc)
     end
 
-    private
-    
-    def extention_process_xml(doc)
-    end
-    
-    def has_result_data?
-      !!score
-    end
-    
-    def results(node)
-      return unless has_result_data?
-      
-      node.result do |res|
-        result_values(res)
-      end
-    end
-
-    def result_values(node)
-      if score
-        node.resultScore do |res_score|
-          res_score.language "en" # 'en' represents the format of the number
-          res_score.textString score.to_s
-        end
-      end
-    end
-
-    def has_required_attributes?
-      @consumer_key && @consumer_secret && @lis_outcome_service_url && @lis_result_sourcedid && @operation
-    end
-
     def generate_request_xml
+      raise IMS::LTI::InvalidLTIConfigError, "`@operation` and `@lis_result_sourcedid` are required" unless has_request_xml_attributes?
       builder = Builder::XmlMarkup.new #(:indent=>2)
       builder.instruct!
 
@@ -202,5 +173,38 @@ module IMS::LTI
       end
     end
 
+    private
+
+    def extention_process_xml(doc)
+    end
+
+    def has_result_data?
+      !!score
+    end
+
+    def results(node)
+      return unless has_result_data?
+
+      node.result do |res|
+        result_values(res)
+      end
+    end
+
+    def result_values(node)
+      if score
+        node.resultScore do |res_score|
+          res_score.language "en" # 'en' represents the format of the number
+          res_score.textString score.to_s
+        end
+      end
+    end
+
+    def has_required_attributes?
+      @consumer_key && @consumer_secret && @lis_outcome_service_url && @lis_result_sourcedid && @operation
+    end
+
+    def has_request_xml_attributes?
+      @operation && @lis_result_sourcedid
+    end
   end
 end

--- a/spec/outcome_request_spec.rb
+++ b/spec/outcome_request_spec.rb
@@ -47,4 +47,15 @@ describe IMS::LTI::OutcomeRequest do
     req.score.should == nil
   end
 
+  it "should generate request xml" do
+    req = IMS::LTI::OutcomeRequest.new(
+                                      :lis_result_sourcedid => '1234',
+                                      :score => 0.5,
+                                      :operation => IMS::LTI::OutcomeRequest::REPLACE_REQUEST
+    )
+    xml = req.generate_request_xml
+    xml.should be_a String
+    xml.should include '<sourcedId>1234</sourcedId>'
+    xml.should include '<replaceResultRequest><resultRecord><sourcedGUID><sourcedId>1234</sourcedId></sourcedGUID><result><resultScore><language>en</language><textString>0.5</textString></resultScore></result></resultRecord></replaceResultRequest>'
+  end
 end


### PR DESCRIPTION
We have a use case in our TP application where we need to send an LTI Outcome Service request to a TC after some time has passed from the session generated by the initial LTI launch. This requires us to save the `lis_outcome_service_url` and `lis_result_sourcedid` which, combined with a key and secret, can be used to `POST` an outcome to the TC.

This pattern appears to be aligned with and in fact explicitly mentioned in the spec (https://www.imsglobal.org/specs/ltiv1p1/implementation-guide):

>  The TP may retain the lis_outcome_service_url and lis_result_sourcedid from a launch and then call the service long after the user's session has ended.  This allows the TP to collect grades and upload them to the TC in batches or perhaps collect grades and upload them to the TP when an instructor clicks a button within the TP.

This gem _almost_ works perfectly for this with one small exception. We already have a webhook architecture built into our application, so in order to leverage that, after we save `lis_outcome_service_url` and `lis_result_sourcedid`, the pattern we are using to send the outcome to the TC is something like this:

First, generate the request body, which is the responsibility of _one_ part of our webhook architecture:
```ruby
def generate_body
	IMS::LTI::OutcomeRequest.new(
	  :lis_result_sourcedid => 1234,
	  :score => 0,5,
	  :operation => IMS::LTI::OutcomeRequest::REPLACE_REQUEST
	).send(:generate_request_xml) # Yikes! Calling a private method!
end

```

Then generate the OAuth signed request, which is the responsibility of a _different_ part of our webhook architecture:
```ruby
IMS::LTI.post_service_request('key', 'sekret', 'http://example.com/lti-outcomes', 'application/xml', generate_body)
```

Since saving `lis_outcome_service_url` and `lis_result_sourcedid` for later use is mentioned in the spec, and generating a request body and making a request are slightly different concerns, this seems like a reasonable architecture to support as part of the public interface of this gem.

This PR makes the `OutcomeRequest#generate_request_xml` a public method. It includes some validation regarding what values need to be available before calling the method, but happy to change that if that's not the intention of `IMS::LTI::InvalidLTIConfigError`. With this change, you can safely do this:

```ruby
def generate_body
	IMS::LTI::OutcomeRequest.new(
	  :lis_result_sourcedid => 1234,
	  :score => 0,5,
	  :operation => IMS::LTI::OutcomeRequest::REPLACE_REQUEST
	).generate_request_xml
end

```

This also partially addresses #49