### PR TITLE
relax oauth dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - "1.9.3"
   - "2.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem "oauth",   "~>0.4.5"
-gem "builder"
-
-group :test do
-  gem 'rspec', :require => "spec"
-end
+gemspec

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "1.1.12"
 
   s.add_dependency 'builder'
-  s.add_dependency 'oauth', '~> 0.4.5'
+  s.add_dependency 'oauth', '>= 0.4.5'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'ruby-debug'

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "1.1.12"
 
   s.add_dependency 'builder'
-  s.add_dependency 'oauth', '>= 0.4.5'
+  s.add_dependency 'oauth', '>= 0.4.5', '< 0.6'
 
   s.add_development_dependency 'rspec'
 

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth', '>= 0.4.5'
 
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'ruby-debug'
 
   s.authors = ["Instructure"]
   s.date = %q{2015-01-09}


### PR DESCRIPTION
The `oauth` gem was recently updated from `0.4.x` to `0.5.x`, which contains a fix to oauth-xx/oauth-ruby#13 which is necessary to use this library with Rails 5. This PR relaxes the `oauth` dependency to allow this library to be used with the newer `0.5.x` versions of that dependency.