### PR TITLE
add request to valid_request? OAuth::Unauthorized

### DIFF
--- a/lib/ims/lti/request_validator.rb
+++ b/lib/ims/lti/request_validator.rb
@@ -18,13 +18,19 @@ module IMS::LTI
     def valid_request?(request, handle_error=true)
       begin
         @oauth_signature_validator = OAuth::Signature.build(request, :consumer_secret => @consumer_secret)
-        @oauth_signature_validator.verify() or raise OAuth::Unauthorized
+        @oauth_signature_validator.verify() or raise OAuth::Unauthorized.new(request)
         true
-      rescue OAuth::Signature::UnknownSignatureMethod, OAuth::Unauthorized
+      rescue OAuth::Signature::UnknownSignatureMethod
         if handle_error
           false
         else
           raise $!
+        end
+      rescue OAuth::Unauthorized
+        if handle_error
+          false
+        else
+          raise OAuth::Unauthorized.new(request)
         end
       end
     end

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+describe IMS::LTI::RequestValidator do
+  context "invalid request" do
+    let(:oauth_signature_validator) { double("oauth_signature_validator") }
+    before do
+      create_params
+      @tool = IMS::LTI::ToolProvider.new("hooi", 'oi', @params)
+    end
+
+    it "should raise OAuth::Unauthorized" do
+      request = Net::HTTP::Post.new('/test?key=value')
+      allow(OAuth::Signature).to receive(:build).and_return(oauth_signature_validator)
+      allow(oauth_signature_validator).to receive(:verify).and_return(false)
+      expect do
+        @tool.valid_request?(request, false)
+      end.to raise_error(OAuth::Unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
The request needs to be passed into OAuth::Unauthorized.new because when the it is being stringified with to_s it expects it:

https://github.com/pelle/oauth/blob/master/lib/oauth/errors/unauthorized.rb

This PR adds the request when raising OAuth::Unauthorized