### PR TITLE
bump simple_oauth to 0.3.1

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'simple_oauth', '0.2'
+  spec.add_dependency 'simple_oauth', '0.3.1'
   spec.add_dependency 'faraday', '~> 0.8'
   spec.add_dependency 'faraday_middleware', '~> 0.8'
   spec.add_dependency 'builder'
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'listen', '~> 2.10.1'
   spec.add_development_dependency 'pry', '~> 0.10.1'
   spec.add_development_dependency 'byebug', '~> 8.2'
-
 end


### PR DESCRIPTION
I went through all the commits merged to simple_oauth since 0.2.0 and these are the only two that actually changed functionality (everything else was style and test coverage):

- https://github.com/laserlemon/simple_oauth/commit/62147887a6da2f073e140e656f59887cc9d09eae
- https://github.com/laserlemon/simple_oauth/commit/07c7f800795189b889d2bb3798197a46946d8009

Basically just validating that there aren't extra options passed in.  Based on how we split up options here: https://github.com/instructure/ims-lti/blob/2.1.x/lib/ims/lti/services/message_authenticator.rb#L55, this seems totally safe to me.