### PR TITLE
Don't downcase roles

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+2017-03-08 Version 1.2.0
+    * Don't downcase roles
+
 2016-10-05 Version 1.1.13
     * Fix Oauth::Unauthorized initialization bug
     * Relax oauth dependency

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = "1.1.13"
+  s.version = "1.2.0"
 
   s.add_dependency 'builder'
   s.add_dependency 'oauth', '0.4.5'

--- a/lib/ims/lti.rb
+++ b/lib/ims/lti.rb
@@ -2,6 +2,7 @@ require 'oauth'
 require 'builder'
 require "rexml/document"
 require 'cgi'
+require 'securerandom'
 
 module IMS # :nodoc:
 

--- a/lib/ims/lti/deprecated_role_checks.rb
+++ b/lib/ims/lti/deprecated_role_checks.rb
@@ -6,7 +6,7 @@ module DeprecatedRoleChecks
   # Check whether the Launch Parameters have a role
     def has_role?(role)
       role = role.downcase
-      @roles && @roles.any?{|r| r.index(role)}
+      @roles && @roles.any?{|r| r.downcase.index(role)}
     end
 
     # Convenience method for checking if the user has 'learner' or 'student' role

--- a/lib/ims/lti/launch_params.rb
+++ b/lib/ims/lti/launch_params.rb
@@ -96,7 +96,7 @@ module IMS::LTI
         if roles_list.is_a?(Array)
           @roles = roles_list
         else
-          @roles = roles_list.split(",").map(&:downcase)
+          @roles = roles_list.split(",")
         end
       else
         @roles = nil

--- a/lib/ims/lti/role_checks.rb
+++ b/lib/ims/lti/role_checks.rb
@@ -16,7 +16,7 @@ module IMS::LTI
     # Check whether the Launch Parameters have a given role
     def has_exact_role?(role)
       role = role.downcase
-      @roles && @roles.any? { |r| r == role }
+      @roles && @roles.any? { |r| r.downcase == role }
     end
 
     # Check whether the Launch Parameters have a given role ignoring
@@ -25,7 +25,7 @@ module IMS::LTI
     # will return true if the role is `urn:lti:role:ims/lis/Instructor/GuestInstructor`
     def has_base_role?(role)
       role = role.downcase
-      @roles && @roles.any? { |r| r.start_with?(role) }
+      @roles && @roles.any? { |r| r.downcase.start_with?(role) }
     end
 
     # Convenience method for checking if the user is the system administrator of the TC

--- a/spec/launch_params_spec.rb
+++ b/spec/launch_params_spec.rb
@@ -11,7 +11,7 @@ describe IMS::LTI::LaunchParams do
         valid_params.each_pair do |key, val|
           @tool.send(key).should == val unless key =~ /\A(?:custom_.+|ext_.+|roles)\Z/
         end
-        @tool.roles.should == ["learner", "instructor", "observer", "urn:lti:role:ims/lis/member", "mentor/mentor", "administrator", "urn:lti:role:ims/lis/teachingassistant/teachingassistantsection"]
+        @tool.roles.should == ["Learner", "Instructor", "Observer", "urn:lti:role:ims/lis/Member", "Mentor/Mentor", "Administrator", "urn:lti:role:ims/lis/TeachingAssistant/TeachingAssistantSection"]
 
         @tool.to_params.should == valid_params
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ def create_params
             "invalid_ext_param" => "invalid_param",
             "invalid_custom_param" => "invalid_custom",
             "ext_lti_message_type" => "extension-lti-launch",
-            "roles" => "learner,instructor,observer,urn:lti:role:ims/lis/member,mentor/mentor,administrator,urn:lti:role:ims/lis/teachingassistant/teachingassistantsection"
+            "roles" => "Learner,Instructor,Observer,urn:lti:role:ims/lis/Member,Mentor/Mentor,Administrator,urn:lti:role:ims/lis/TeachingAssistant/TeachingAssistantSection"
     }
 end
 

--- a/spec/tool_consumer_spec.rb
+++ b/spec/tool_consumer_spec.rb
@@ -26,14 +26,14 @@ describe IMS::LTI::ToolConsumer do
   it "should generate a correct signature" do
     create_tc
     res = @tc.generate_launch_data
-    res['oauth_signature'].should eql('Eh+W+ZMn4CB9momDqyJXf5yMfTc=')
+    res['oauth_signature'].should eql('TPFPK4u3NwmtLt0nDMP1G1zG30U=')
   end
 
   it "should generate a correct signature with URL query parameters" do
     create_tc
     @tc.launch_url = 'http://dr-chuck.com/ims/php-simple/tool.php?a=1&b=2&c=3%20%26a'
     res = @tc.generate_launch_data
-    res['oauth_signature'].should eql('iN1kwF7CYLWi0BJCo3G7rlGHTm8=')
+    res['oauth_signature'].should eql('uF7LooyefQN5aocx7UlYQ4tQM5k=')
     res['c'].should == "3 &a"
   end
 


### PR DESCRIPTION
Fixes https://github.com/instructure/ims-lti/issues/77.

At Instructure we have hit some problems when using [rack-lti](https://github.com/zachpendleton/rack-lti)'s `success` callback, which receives the lti params as its first argument. We're expecting roles to have the correct case, but the `ToolProvider` is downcasing them.

This pull request removes the code that downcases roles. The role check helper methods still work in a case-insensitive way for backward-compatibility.