### PR TITLE
Update oauth version dependency

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "1.2.1"
 
   s.add_dependency 'builder'
-  s.add_dependency 'oauth', '0.4.5'
+  s.add_dependency 'oauth', '>= 0.4.5', '<= 0.6'
 
   s.add_development_dependency 'rspec'
 


### PR DESCRIPTION
> error - cannot load such file -- action_controller/request
> require 'oauth/request_proxy/action_controller_request'

after update oauth version its working fine 

Fixed add_dependency issue because it is not working on rails 5 so fixed that issue by changed version rang between  '>= 0.4.5' to '<= 0.6'.