### PR TITLE
Decode JSON before parsing

### DIFF
--- a/lib/ims/lti/models/lti_model.rb
+++ b/lib/ims/lti/models/lti_model.rb
@@ -1,4 +1,6 @@
 module IMS::LTI::Models
+    require 'uri'
+  
   class LTIModel
     LTI_VERSION_2P0 = 'LTI-2p0'.freeze
     LTI_VERSION_2P1 = 'LTI-2p1'.freeze
@@ -90,6 +92,7 @@ module IMS::LTI::Models
     end
 
     def from_json(json)
+      json = URI.unescape(json)
       # JSON.parse(json.to_json) is a quick and dirty way to clone the json object passed in
       data = json.is_a?(String) ? JSON.parse(json) : JSON.parse(json.to_json)
       if data.is_a? Array

--- a/lib/ims/lti/models/lti_model.rb
+++ b/lib/ims/lti/models/lti_model.rb
@@ -92,9 +92,8 @@ module IMS::LTI::Models
     end
 
     def from_json(json)
-      json = URI.unescape(json)
       # JSON.parse(json.to_json) is a quick and dirty way to clone the json object passed in
-      data = json.is_a?(String) ? JSON.parse(json) : JSON.parse(json.to_json)
+      data = json.is_a?(String) ? JSON.parse(URI.unescape(json)) : JSON.parse(URI.unescape(json.to_json))
       if data.is_a? Array
         data.map { |hash| self.class.from_json(hash.to_json) }
       else

--- a/spec/ims/lti/models/lti_model_spec.rb
+++ b/spec/ims/lti/models/lti_model_spec.rb
@@ -190,6 +190,11 @@ module IMS::LTI::Models
       end
 
       describe '#from_json' do
+        it 'decodes encoded json' do
+          encoded_json = '%7B%22two%22%3A%20%7B%22a%22%3A%20%22a%22%7D%7D'
+          model = SampleClass.new.from_json(encoded_json)
+          expect(model.two.a).to eq 'a'
+        end
 
         it 'deserializes json with json key mappings' do
           model = SampleClass.new.from_json('{"@one":1}')


### PR DESCRIPTION
We should support both encoded and decoded JSON within the content_items
IMS spec says:

> Note that the JSON value of the content_items parameter should be encoded to ensure that the HTML of the page is valid. At a minimum any instances of the quotation character used to delimit the attribute value need to be encoded.

See PLAT-2714