### PR TITLE
remove builder dependency

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.1'
-  spec.add_dependency 'builder', '~> 3.2'
   spec.add_dependency 'faraday', '~> 0.8'
   spec.add_dependency 'faraday_middleware', '~> 0.8'
   spec.add_dependency 'json-jwt', '~> 1.7'


### PR DESCRIPTION
i was having trouble getting the deps to line up with an old rails project and one of the issues was that the pinned version of `builder` was too high. browsing through the source of the project, it looks like this a transitive dep, so perhaps it isn't something that needs to be pinned here. 