### PR TITLE
[1.2.4] Version Bump

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+2020-02-03 Version 1.2.4
+    * Add support for submittedAt date
+
 2017-03-08 Version 1.2.0
     * Don't downcase roles
 

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = "1.2.2"
+  s.version = "1.2.4"
 
-  s.add_dependency 'builder'
+  s.add_dependency 'builder', '>= 1.0', '< 4.0'
   s.add_dependency 'oauth', '>= 0.4.5', '< 0.6'
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.0', '> 3.0'
 
   s.authors = ["Instructure"]
   s.extra_rdoc_files = %W(LICENSE)


### PR DESCRIPTION
Did version 1.2.4 instead of 1.2.3 because 1.2.3 compiled with a bad dependency.