### PR TITLE
Allow faraday up to < 2

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_dependency 'builder', '~> 3.2'
-  spec.add_dependency 'faraday', '~> 0.8'
-  spec.add_dependency 'faraday_middleware', '~> 0.8'
+  spec.add_dependency 'faraday', '< 2'
+  spec.add_dependency 'faraday_middleware', '< 2'
   spec.add_dependency 'json-jwt', '~> 1.7'
   spec.add_dependency 'simple_oauth', '~> 0.3.1'
 


### PR DESCRIPTION
Because of the hard dependency on faraday, it's difficult to upgrade
apps to new versions. This resolves that by setting a higher minimum
version of faraday.