### PR TITLE
convert newlines to CRLFs in base string params

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware', '< 2.0'
   spec.add_dependency 'json-jwt', '~> 1.7'
   spec.add_dependency 'simple_oauth', '~> 0.3.1'
+  spec.add_dependency 'rexml'
 
   spec.add_development_dependency 'byebug', '~> 9.0'
   spec.add_development_dependency 'guard', '~> 2.13'

--- a/lib/ims/lti/version.rb
+++ b/lib/ims/lti/version.rb
@@ -1,5 +1,5 @@
 module IMS
   module LTI
-    VERSION = "2.3.1"
+    VERSION = "2.3.2"
   end
 end


### PR DESCRIPTION
Browsers convert newlines to CRLF when submitting a form.

I also added the 'rexml' dependency which will be required starting from
Ruby >= 3.0; Canvas already includes it in its Gemfile.lock. Adding it
doesn't cause any problems for any versions of Ruby we already support
(I think one of our gems requires >=2.7 already)