### PR TITLE
Fix content return parameter encoding

### DIFF
--- a/lib/ims/lti/extensions/content.rb
+++ b/lib/ims/lti/extensions/content.rb
@@ -96,67 +96,116 @@ module IMS::LTI
 
         #generates the return url for file submissions
         def file_content_return_url(url, text, content_type = nil)
-          url = CGI::escape(url)
-          text = CGI::escape(text)
-          content_type = CGI::escape(content_type) if content_type
 
-          return_url = "#{content_return_url}?return_type=file&url=#{url}&text=#{text}"
-          return_url = "#{return_url}&content_type=#{content_type}" if content_type
+          return_url = add_parameters(content_return_url, {
+            return_type: 'file',
+            url: url,
+            text: text
+          })
+
+          if content_type
+            return_url = add_parameters(return_url, {
+              content_type: content_type
+            })
+          end
 
           return return_url
         end
 
         #generates the return url for url submissions
         def url_content_return_url(url, title = nil, text = 'link', target = '_blank')
-          url = CGI::escape(url)
-          text = CGI::escape(text)
-          target = CGI::escape(target)
 
-          return_url = "#{content_return_url}?return_type=url&url=#{url}&text=#{text}&target=#{target}"
-          return_url = "#{return_url}&title=#{CGI::escape(title)}" if title
+          return_url = add_parameters(content_return_url, {
+            return_type: 'url',
+            url: url,
+            text: text,
+            target: target
+          })
+
+          if title
+            return_url = add_parameters(return_url, {
+              title:title
+            })
+          end
 
           return return_url
         end
 
         #generates the return url for lti launch submissions
         def lti_launch_content_return_url(url, text='link', title=nil)
-          url = CGI::escape(url)
-          text = CGI::escape(text)
 
-          return_url = "#{content_return_url}?return_type=lti_launch_url&url=#{url}&text=#{text}"
-          return_url = "#{return_url}&title=#{CGI::escape(title)}" if title
+          return_url = add_parameters(content_return_url, {
+            return_type: 'lti_launch_url',
+            url: url,
+            text: text
+          })
+
+          if title
+            return_url = add_parameters(return_url, {
+              title:title
+            })
+          end
 
           return return_url
         end
 
         #generates the return url for image submissions
         def image_content_return_url(url, width, height, alt = '')
-          url = CGI::escape(url)
-          width = CGI::escape(width.to_s)
-          height = CGI::escape(height.to_s)
-          alt = CGI::escape(alt)
 
-          "#{content_return_url}?return_type=image_url&url=#{url}&width=#{width}&height=#{height}&alt=#{alt}"
+          add_parameters(content_return_url, {
+            return_type: 'image_url',
+            url: url,
+            width: width.to_s,
+            height: height.to_s,
+            alt: alt
+          })
         end
 
         #generates the return url for iframe submissions
         def iframe_content_return_url(url, width, height, title = nil)
-          url = CGI::escape(url)
-          width = CGI::escape(width.to_s)
-          height = CGI::escape(height.to_s)
 
-          return_url = "#{content_return_url}?return_type=iframe&url=#{url}&width=#{width}&height=#{height}"
-          return_url = "#{return_url}&title=#{CGI::escape(title)}" if title
+          return_url = add_parameters(content_return_url, {
+            return_type: 'iframe',
+            url: url,
+            width: width.to_s,
+            height: height.to_s
+          })
+
+          if title
+            return_url = add_parameters(return_url, {
+              title:title
+            })
+          end
 
           return return_url
         end
 
         #generates the return url for oembed submissions
         def oembed_content_return_url(url, endpoint)
-          url = CGI::escape(url)
-          endpoint = CGI::escape(endpoint)
 
-          "#{content_return_url}?return_type=oembed&url=#{url}&endpoint=#{endpoint}"
+          add_parameters(content_return_url, {
+            return_type: 'oembed',
+            url: url,
+            endpoint: endpoint
+          })
+        end
+
+        private
+
+        # adds parameters to a url, with consideration for
+        # already existing parameters
+        def add_parameters(url, params)
+          parsed = URI.parse(url)
+          query = if parsed.query
+                    CGI.parse(parsed.query)
+                  else
+                    {}
+                  end
+
+          query = query.merge(params)
+
+          parsed.query = URI.encode_www_form(query)
+          parsed.to_s
         end
       end
 

--- a/spec/extensions/content_spec.rb
+++ b/spec/extensions/content_spec.rb
@@ -5,7 +5,7 @@ describe IMS::LTI::Extensions do
     create_params
     @params['ext_content_intended_use'] = "homework"
     @params['ext_content_return_types'] = "file,url,lti_launch_url,image_url,iframe,oembed"
-    @params['ext_content_return_url'] = "http://example.com/content_return"
+    @params['ext_content_return_url'] = "http://example.com/content_return?extra_param=foo"
     @params['ext_content_file_extensions'] = 'txt,jpg'
     @tp = IMS::LTI::ToolProvider.new("hi", 'oi', @params)
     @tp.extend IMS::LTI::Extensions::Content::ToolProvider
@@ -48,60 +48,77 @@ describe IMS::LTI::Extensions do
     let(:alt) {"Alternate text"}
     let(:endpoint) {"http://endpoint.com"}
 
+    def url_params(url)
+      parsed = URI.parse(url)
+      return CGI.parse(parsed.query) if parsed&.query
+    end
+
     it "should generate a file return url" do
       return_url = @tp.file_content_return_url(url, text, content_type)
 
-      return_url.include?("return_type=file").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("text=#{CGI::escape(text)}").should == true
-      return_url.include?("content_type=#{CGI::escape(content_type)}").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "file"
+      return_params["url"][0].should == url
+      return_params["text"][0].should == text
+      return_params["content_type"][0].should == content_type
     end
 
     it "should generate a url return url" do
       return_url = @tp.url_content_return_url(url, title, text, '_blank')
 
-      return_url.include?("return_type=url").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("title=#{CGI::escape(title)}").should == true
-      return_url.include?("text=#{CGI::escape(text)}").should == true
-      return_url.include?("target=_blank").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "url"
+      return_params["url"][0].should == url
+      return_params["title"][0].should == title
+      return_params["text"][0].should == text
+      return_params["target"][0].should == "_blank"
     end
 
     it "should generate a lti launch return url" do
       return_url = @tp.lti_launch_content_return_url(url, text, title)
 
-      return_url.include?("return_type=lti_launch_url").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("text=#{CGI::escape(text)}").should == true
-      return_url.include?("title=#{CGI::escape(title)}").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "lti_launch_url"
+      return_params["url"][0].should == url
+      return_params["text"][0].should == text
+      return_params["title"][0].should == title
     end
 
     it "should generate a image return url" do
       return_url = @tp.image_content_return_url(url, width, height, alt)
 
-      return_url.include?("return_type=image_url").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("width=#{width}").should == true
-      return_url.include?("height=#{height}").should == true
-      return_url.include?("alt=#{CGI::escape(alt)}").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "image_url"
+      return_params["url"][0].should == url
+      return_params["width"][0].should == "#{width}"
+      return_params["height"][0].should == "#{height}"
+      return_params["alt"][0].should == alt
     end
 
     it "should generate an iframe return url" do
       return_url = @tp.iframe_content_return_url(url, width, height, title)
 
-      return_url.include?("return_type=iframe").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("width=#{width}").should == true
-      return_url.include?("height=#{height}").should == true
-      return_url.include?("title=#{CGI::escape(title)}").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "iframe"
+      return_params["url"][0].should == url
+      return_params["width"][0].should == "#{width}"
+      return_params["height"][0].should == "#{height}"
+      return_params["title"][0].should == title
     end
 
     it "should generate an oembed return url" do
       return_url = @tp.oembed_content_return_url(url, endpoint)
 
-      return_url.include?("return_type=oembed").should == true
-      return_url.include?("url=#{CGI::escape(url)}").should == true
-      return_url.include?("endpoint=#{CGI::escape(endpoint)}").should == true
+      return_params = url_params(return_url)
+
+      return_params["return_type"][0].should == "oembed"
+      return_params["url"][0].should == url
+      return_params["endpoint"][0].should == endpoint
     end
   end
 


### PR DESCRIPTION
This fixes an issue that arises when a Tool Consumer sends a return url with pre-provided parameters.

```
ext_content_return_url=http://example.com?foo=bar
```

Before, this library was blindly adding parameters to that url, which would redirect the user back to:

```
http://example.com?foo=bar?return_type=image_url&url=http%3A%2F%2Fexample.com%2Flogo.png
                          ^ extra ? in the query
```

This fixes the issue by parsing the return url, and adding parameters via `CGI`