### PR TITLE
Fix deprecated method usage

### DIFF
--- a/lib/ims/lti/models/lti_model.rb
+++ b/lib/ims/lti/models/lti_model.rb
@@ -1,6 +1,6 @@
+require 'uri'
+
 module IMS::LTI::Models
-    require 'uri'
-  
   class LTIModel
     LTI_VERSION_2P0 = 'LTI-2p0'.freeze
     LTI_VERSION_2P1 = 'LTI-2p1'.freeze
@@ -96,7 +96,7 @@ module IMS::LTI::Models
       begin
         data = JSON.parse(json)
       rescue
-        data = JSON.parse(URI.unescape(json))
+        data = JSON.parse(URI::DEFAULT_PARSER.unescape(json))
       end
 
       if data.is_a? Array

--- a/lib/ims/lti/version.rb
+++ b/lib/ims/lti/version.rb
@@ -1,5 +1,5 @@
 module IMS
   module LTI
-    VERSION = "2.3.2"
+    VERSION = "2.3.3"
   end
 end

--- a/spec/ims/lti/models/messages/message_spec.rb
+++ b/spec/ims/lti/models/messages/message_spec.rb
@@ -181,7 +181,7 @@ module IMS::LTI::Models::Messages
 
         it "converts newlines in query params to CRLFs to match what browsers do" do
           message.custom_user_id = "abc\ndef"
-          message.launch_url = "http://www.exampAle.com"
+          message.launch_url = "http://www.example.com"
           message.oauth_consumer_key = "key"
 
           expect(described_class).to \


### PR DESCRIPTION
Also fix a spec I accidentally have had a typo in for a while, it appears.

Also I bumped the version

Note that it appears URI::DEFAULT_PARSER has been around since at least ruby 2.0:
https://ruby-doc.org/stdlib-2.0.0/libdoc/uri/rdoc/URI/Generic.html

refs INTEROP-7884

Test plan:
- change the line with unescape to "data = {}" and make sure that specs fail
- make sure that specs pass with ruby major versions (remove Gemfile.lock and bundle install after each ruby version change). I checked with:
  - 2.5.8
  - 2.6.4
  - 2.7.6
  - 3.0.1
  - 3.0.2
  - 3.1.2