### PR TITLE
ruby 3.0 support & fix URI encoding bug

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -1,9 +1,10 @@
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = "1.2.7"
+  s.version = "1.2.8"
 
   s.add_dependency 'builder', '>= 1.0', '< 4.0'
   s.add_dependency 'oauth', '>= 0.4.5', '< 0.6'
+  s.add_dependency 'rexml'
 
   s.add_development_dependency 'rspec', '~> 3.0', '> 3.0'
 

--- a/lib/ims/lti/tool_provider.rb
+++ b/lib/ims/lti/tool_provider.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module IMS::LTI
 
   # Class for implementing an LTI Tool Provider
@@ -121,7 +123,7 @@ module IMS::LTI
       messages = []
       %w{lti_errormsg lti_errorlog lti_msg lti_log}.each do |m|
         if message = self.send(m)
-          messages << "#{m}=#{URI.escape(message)}"
+          messages << "#{m}=#{CGI.escape(message)}"
         end
       end
       q_string = messages.any? ? ("?" + messages.join("&")) : ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,3 +47,8 @@ def mock_request(expected_xml)
   @fake.stub(:body).and_return("<xml/>")
   @fake.should_receive(:post).with(@params['lis_outcome_service_url'], expected_xml, {'Content-Type' => 'application/xml'}).and_return(@fake)
 end
+
+RSpec.configure do |config|
+  config.expect_with(:rspec) { |c| c.syntax = %i[expect should] }
+  config.mock_with(:rspec) { |c| c.syntax = %i[expect should] }
+end

--- a/spec/tool_provider_spec.rb
+++ b/spec/tool_provider_spec.rb
@@ -16,8 +16,8 @@ describe IMS::LTI::ToolProvider do
     @tp.lti_errormsg = "user error message"
     @tp.lti_errorlog = "lms error log"
     @tp.lti_msg = "user message"
-    @tp.lti_log = "lms message"
-    @tp.build_return_url.should == @params['launch_presentation_return_url'] + "?lti_errormsg=user%20error%20message&lti_errorlog=lms%20error%20log&lti_msg=user%20message&lti_log=lms%20message"
+    @tp.lti_log = "lms message & stuff"
+    @tp.build_return_url.should == @params['launch_presentation_return_url'] + "?lti_errormsg=user+error+message&lti_errorlog=lms+error+log&lti_msg=user+message&lti_log=lms+message+%26+stuff"
   end
 
   it "should find the base role" do


### PR DESCRIPTION
CGI.escape() should be used here as the output is used in query params: URI.escape("&") is actually "&", which would mess up a query param.

Also, rexml is now an external gem and needs to be explicitly stated as a dependency.

refs INTEROP-7884

Test plan:
- Run specs on major Ruby versions (I've tested 2.4 - 3.1)