### PR TITLE
Loosen version requirement for OAuth gem

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version = "1.2.8"
 
   s.add_dependency 'builder', '>= 1.0', '< 4.0'
-  s.add_dependency 'oauth', '>= 0.4.5', '< 0.6'
+  s.add_dependency 'oauth', '>= 0.4.5'
   s.add_dependency 'rexml'
 
   s.add_development_dependency 'rspec', '~> 3.0', '> 3.0'


### PR DESCRIPTION
Newer versions mainly include bug fixes, support newer Ruby versions, and partly drop support for older Ruby versions. Through the new version range specified with `>= 0.4.5`, we still allow the same OAuth gem version, but additionally allow all newer versions. Those do not contain any breaking changes.

See https://gitlab.com/oauth-xx/oauth/-/blob/main/CHANGELOG.md

<hr>

The changes I performed are similar to the ones discussed [here](https://github.com/Sorcery/sorcery/issues/317#issuecomment-1272019639) by one of the OAuth gem maintainers. According to that discussion and my own analysis, newer versions of the OAuth gem do not contain any breaking changes.

@slaughter550: I would be happy if you could review my PR and potentially draft a new release -- thanks!