### PR TITLE
feat(faraday): upgrade to version 2

### DIFF
--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_dependency 'builder', '~> 3.2'
-  spec.add_dependency 'faraday', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '< 2.0'
+  spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'json-jwt', '~> 1.7'
   spec.add_dependency 'simple_oauth', '~> 0.3.1'
   spec.add_dependency 'rexml'

--- a/lib/ims/lti.rb
+++ b/lib/ims/lti.rb
@@ -1,7 +1,6 @@
 require 'addressable/uri'
 require 'builder'
 require 'faraday'
-require 'faraday_middleware'
 require 'json'
 require 'json/jwt'
 require 'rexml/document'

--- a/lib/ims/lti/services/oauth2_client.rb
+++ b/lib/ims/lti/services/oauth2_client.rb
@@ -11,7 +11,7 @@ module IMS::LTI::Services
 
     def connection
       @connection ||= Faraday.new base_url do |conn|
-        conn.authorization :Bearer, token
+        conn.headers['Authorization'] = "Bearer #{token}"
       end
     end
   end

--- a/lib/ims/lti/version.rb
+++ b/lib/ims/lti/version.rb
@@ -1,5 +1,5 @@
 module IMS
   module LTI
-    VERSION = "2.3.3"
+    VERSION = "2.3.4"
   end
 end


### PR DESCRIPTION
The faraday_middleware gem is not necessary anymore and thus can be removed. In order to get the specs to work I had to change the way how we should set the Authorization header.