### PR TITLE
Change branch name for Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     stage('Deploy') {
       when {
         allOf {
-          expression { GIT_BRANCH == "master" }
+          expression { GIT_BRANCH == "main" }
         }
       }
       steps {

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.5', '>= 2.5.1'
   spec.add_dependency 'builder', '~> 3.2'
   spec.add_dependency 'faraday', '< 3.0'
-  spec.add_dependency 'json-jwt', '~> 1.7'
+  spec.add_dependency 'json-jwt', '~> 1.16.6'
   spec.add_dependency 'simple_oauth', '~> 0.3.1'
   spec.add_dependency 'rexml'
 

--- a/lib/ims/lti/version.rb
+++ b/lib/ims/lti/version.rb
@@ -1,5 +1,5 @@
 module IMS
   module LTI
-    VERSION = "2.3.4"
+    VERSION = "2.3.5"
   end
 end


### PR DESCRIPTION
The master branch was renamed to main a few months ago,
but Jenkins is still checking to see if a commit has been
merged to the "master" branch before pushing a new version
to rubygems.